### PR TITLE
Access attributes with magic getter

### DIFF
--- a/YouTrack/BaseObject.php
+++ b/YouTrack/BaseObject.php
@@ -45,6 +45,10 @@ class BaseObject implements \Iterator
         if (!empty($this->attributes[$name])) {
             return $name;
         }
+        $name = str_replace( '_', " ", $oName);
+        if (!empty($this->attributes[$name])) {
+            return $name;
+        }
         return $oName;
     }
 


### PR DESCRIPTION
YouTrack uses attributes like 'Spend time' with s Space and also no camelCcase if the space is added.

`var_dump($issue->getSpent_time());` or any custom field