### PR TITLE
fix creating `Comment` for `Issue` on its load (Fatal error)

### DIFF
--- a/YouTrack/Issue.php
+++ b/YouTrack/Issue.php
@@ -124,7 +124,7 @@ class Issue extends BaseObject
         foreach ($xml->children() as $nodeName => $node) {
             /** @var \SimpleXMLElement $node */
             if ($nodeName == 'comment') {
-                $this->comments[] = new Comment(new \SimpleXMLElement($node->asXML()));
+                $this->comments[] = new Comment(new \SimpleXMLElement($node->asXML()), $this->youtrack);
                 continue;
             }
             foreach ($node->attributes() as $key => $value) {


### PR DESCRIPTION
### As for now:
 - issue load via rest
 - create instance of `Issue`:
   - call `BaseObject::__construct()` (_and pass `Connection`_)
   - fill attributes via `BaseObject::update()`:
     - fill children attributes via `Issue::updateChildrenAttributes()`:
       - here we fill comments and create instances of `Comment`, **but not pass the `Connection`**

so, if then we call something like `$issue->getComments()[0]->getUser()`, we got the error:
```
PHP Fatal error:  Uncaught Error: Call to a member function getUser() on null in vendor/nepda/youtrack-client/YouTrack/Comment.php:43
```
because the `Connection` was not passed and property `BaseObject::$youtrack` was not set for `Comment` instance.

### After fix:
 - `Connection` passed for `Comment` instances
 - no fatal error