### PR TITLE
Refactor tests to PSR-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,13 @@
     }
   ],
   "autoload": {
-    "psr-0": {
-      "YouTrack\\": "./"
+    "psr-4": {
+      "YouTrack\\": "YouTrack/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "YouTrack\\Test\\": "test/"
     }
   },
   "require": {

--- a/test/AgileBoardSettingTest.php
+++ b/test/AgileBoardSettingTest.php
@@ -1,8 +1,8 @@
 <?php
-namespace YouTrack;
-require_once 'requirements.php';
-require_once 'testconnection.php';
 
+namespace YouTrack\Test;
+
+use YouTrack\AgileSetting;
 
 /**
  * Unit test for the youtrack agile board settings class.
@@ -12,7 +12,7 @@ require_once 'testconnection.php';
 class AgileBoardSettingTest extends \PHPUnit_Framework_TestCase
 {
 
-    private $singleAgileSettingFile = 'test/testdata/agile-boards.xml';
+    private $singleAgileSettingFile = __DIR__ . '/testdata/agile-boards.xml';
 
     public function testCanCreateSimpleAgileSetting()
     {

--- a/test/AttachmentTest.php
+++ b/test/AttachmentTest.php
@@ -1,18 +1,18 @@
 <?php
-namespace YouTrack;
-require_once 'requirements.php';
-require_once 'testconnection.php';
 
+namespace YouTrack\Test;
+
+use YouTrack\Attachment;
 
 /**
  * Unit test for the youtrack attachment class.
  *
  * @author Nepomuk Fraedrich <info@nepda.eu>
  */
-class AttachmentsTest extends \PHPUnit_Framework_TestCase
+class AttachmentTest extends \PHPUnit_Framework_TestCase
 {
 
-    private $singleAttachmentFile = 'test/testdata/attachment.xml';
+    private $singleAttachmentFile = __DIR__ . '/testdata/attachment.xml';
 
     public function testCanCreateSimpleAttachment()
     {
@@ -99,12 +99,12 @@ class AttachmentsTest extends \PHPUnit_Framework_TestCase
     {
         $attachment = $this->createAttachment();
 
-        $expectedResult = unserialize(file_get_contents('test/testdata/request-response-create-attachment-serialized.txt'));
+        $expectedResult = unserialize(file_get_contents(__DIR__ . '/testdata/request-response-create-attachment-serialized.txt'));
 
         /**
          * @var \YouTrack\Connection $youtrack
          */
-        $youtrackBuilder = $this->getMockBuilder('\\YouTrack\\TestConnection');
+        $youtrackBuilder = $this->getMockBuilder('YouTrack\\Test\\TestConnection');
         $youtrackBuilder->setMethods(['request']);
         $youtrack = $youtrackBuilder->getMock();
 
@@ -141,7 +141,7 @@ class AttachmentsTest extends \PHPUnit_Framework_TestCase
         $expectedUrl = '/issue/' . rawurlencode($issueId) . '/attachment?' . http_build_query($params);
         $expectedResult = 'myResponseValue';
 
-        $youtrackBuilder = $this->getMockBuilder('\\YouTrack\\TestConnection');
+        $youtrackBuilder = $this->getMockBuilder('YouTrack\\Test\\TestConnection');
         $youtrackBuilder->setMethods(['request']);
         $youtrack = $youtrackBuilder->getMock();
 
@@ -158,7 +158,7 @@ class AttachmentsTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateAttachmentThrowsExceptionOnNonExistingFile()
     {
-        $youtrackBuilder = $this->getMockBuilder('\\YouTrack\\TestConnection');
+        $youtrackBuilder = $this->getMockBuilder('YouTrack\\Test\\TestConnection');
         $youtrackBuilder->setMethods(['request']);
         $youtrack = $youtrackBuilder->getMock();
 

--- a/test/AutoloadingTest.php
+++ b/test/AutoloadingTest.php
@@ -1,5 +1,6 @@
 <?php
-namespace YouTrack;
+
+namespace YouTrack\Test;
 
 class AutoloadingTest extends \PHPUnit_Framework_TestCase
 {

--- a/test/BaseObjectTest.php
+++ b/test/BaseObjectTest.php
@@ -1,7 +1,7 @@
 <?php
-namespace YouTrack;
+namespace YouTrack\Test;
 
-require_once 'requirements.php';
+use YouTrack\BaseObject;
 
 /**
  * Unit test for the youtrack object class.
@@ -12,7 +12,7 @@ require_once 'requirements.php';
 class BaseObjectTest extends \PHPUnit_Framework_TestCase
 {
 
-    private $filename = 'test/testdata/issue.xml';
+    private $filename = __DIR__ . '/testdata/issue.xml';
 
     public function testConstruct01()
     {

--- a/test/ConnectionTest.php
+++ b/test/ConnectionTest.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace YouTrack;
-require_once 'requirements.php';
-require_once 'testconnection.php';
+namespace YouTrack\Test;
 
 /**
  * Unit test for the connection class.
@@ -16,16 +14,16 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
     public function testCreateConnection()
     {
         $con = new TestConnection();
-        $this->assertInstanceOf('\YouTrack\TestConnection', $con);
+        $this->assertInstanceOf('YouTrack\Test\TestConnection', $con);
     }
 
     public function testIncorrectLoginThrowsException()
     {
         $con = new TestConnection();
-        $refl = new \ReflectionClass('\YouTrack\TestConnection');
+        $refl = new \ReflectionClass('YouTrack\Test\TestConnection');
         $method = $refl->getMethod('handleLoginResponse');
         $method->setAccessible(true);
-        $content = file_get_contents('test/testdata/incorrect-login.http');
+        $content = file_get_contents(__DIR__ . '/testdata/incorrect-login.http');
         $response = [
             'http_code' => 403
         ];

--- a/test/CurrentUserTest.php
+++ b/test/CurrentUserTest.php
@@ -1,6 +1,7 @@
 <?php
-namespace YouTrack;
-require_once 'requirements.php';
+namespace YouTrack\Test;
+
+use YouTrack\CurrentUser;
 
 /**
  * Unit test for fetching current user.
@@ -9,7 +10,7 @@ require_once 'requirements.php';
  */
 class CurrentUserTest extends \PHPUnit_Framework_TestCase
 {
-    private $filename = 'test/testdata/currentuser.xml';
+    private $filename = __DIR__  . '/testdata/currentuser.xml';
 
     public function testConstruct()
     {

--- a/test/EnumFieldTest.php
+++ b/test/EnumFieldTest.php
@@ -1,10 +1,13 @@
 <?php
-namespace YouTrack;
+namespace YouTrack\Test;
+
+use YouTrack\EnumBundle;
+use YouTrack\EnumField;
 
 class EnumFieldTest extends \PHPUnit_Framework_TestCase
 {
 
-    private $filename = 'test/testdata/enum_bundle.xml';
+    private $filename = __DIR__  . '/testdata/enum_bundle.xml';
 
     public function testGetOwnedFieldBundleElements()
     {

--- a/test/ExceptionTest.php
+++ b/test/ExceptionTest.php
@@ -1,6 +1,5 @@
 <?php
-namespace YouTrack;
-require_once 'requirements.php';
+namespace YouTrack\Test;
 
 use YouTrack\Exception as YouTrackException;
 
@@ -19,7 +18,7 @@ class ExceptionTest extends \PHPUnit_Framework_TestCase
             'http_code' => 200,
         ];
         $content = '';
-        $e = new Exception($url, $response, $content);
+        $e = new YouTrackException($url, $response, $content);
         $this->assertEquals("Error for 'http://example.com': 200", $e->getMessage());
     }
 
@@ -30,7 +29,7 @@ class ExceptionTest extends \PHPUnit_Framework_TestCase
             'http_code' => 404,
         ];
         $content = '';
-        $e = new Exception($url, $response, $content);
+        $e = new YouTrackException($url, $response, $content);
         $this->assertEquals("Error for 'http://example.com': 404", $e->getMessage());
     }
 
@@ -42,7 +41,7 @@ class ExceptionTest extends \PHPUnit_Framework_TestCase
             'content_type' => 'text/html; charset=utf8',
         ];
         $content = '';
-        $e = new Exception($url, $response, $content);
+        $e = new YouTrackException($url, $response, $content);
         $this->assertEquals("Error for 'http://example.com': 500", $e->getMessage());
     }
 

--- a/test/IssueTest.php
+++ b/test/IssueTest.php
@@ -1,6 +1,8 @@
 <?php
-namespace YouTrack;
-require_once 'requirements.php';
+namespace YouTrack\Test;
+
+
+use YouTrack\Issue;
 
 /**
  * Unit test for the youtrack issue class.
@@ -11,7 +13,7 @@ require_once 'requirements.php';
 class IssueTest extends \PHPUnit_Framework_TestCase
 {
 
-    private $filename = 'test/testdata/issue.xml';
+    private $filename = __DIR__  . '/testdata/issue.xml';
 
     public function testConstruct01()
     {

--- a/test/OwnedFieldBundleTest.php
+++ b/test/OwnedFieldBundleTest.php
@@ -1,10 +1,13 @@
 <?php
-namespace YouTrack;
+namespace YouTrack\Test;
+
+use YouTrack\OwnedField;
+use YouTrack\OwnedFieldBundle;
 
 class OwnedFieldBundleTest extends \PHPUnit_Framework_TestCase
 {
 
-    private $filename = 'test/testdata/owned_field_bundle.xml';
+    private $filename = __DIR__  . '/testdata/owned_field_bundle.xml';
 
     public function testGetOwnedFieldBundleElements()
     {

--- a/test/RoleTest.php
+++ b/test/RoleTest.php
@@ -1,7 +1,8 @@
 <?php
-namespace YouTrack;
+namespace YouTrack\Test;
 
-require_once 'requirements.php';
+
+use YouTrack\Role;
 
 /**
  * Class RoleTest
@@ -11,8 +12,8 @@ require_once 'requirements.php';
 class RoleTest extends \PHPUnit_Framework_TestCase
 {
 
-    private $rolePlainFile = 'test/testdata/role-plain.xml';
-    private $roleProjectFile = 'test/testdata/role-project-ref.xml';
+    private $rolePlainFile = __DIR__  . '/testdata/role-plain.xml';
+    private $roleProjectFile = __DIR__  . '/testdata/role-project-ref.xml';
 
     public function testCreatePlainRole()
     {

--- a/test/TestConnection.php
+++ b/test/TestConnection.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace YouTrack;
+namespace YouTrack\Test;
+
+use YouTrack\Connection;
 
 /**
  * A helper class for connection testing.

--- a/test/VersionTest.php
+++ b/test/VersionTest.php
@@ -1,6 +1,7 @@
 <?php
-namespace YouTrack;
-require_once 'requirements.php';
+namespace YouTrack\Test;
+
+use YouTrack\Version;
 
 /**
  * Unit test for the YouTrack Version class.
@@ -11,7 +12,7 @@ require_once 'requirements.php';
 class VersionTest extends \PHPUnit_Framework_TestCase
 {
 
-    private $filename = 'test/testdata/version.xml';
+    private $filename = __DIR__  . '/testdata/version.xml';
 
     public function testName()
     {

--- a/test/WorkitemTest.php
+++ b/test/WorkitemTest.php
@@ -1,6 +1,8 @@
 <?php
-namespace YouTrack;
-require_once 'requirements.php';
+namespace YouTrack\Test;
+
+use YouTrack\User;
+use YouTrack\Workitem;
 
 /**
  * Unit test for the youtrack workitem class.
@@ -9,7 +11,7 @@ require_once 'requirements.php';
  */
 class WorkitemTest extends \PHPUnit_Framework_TestCase
 {
-    private $filename = 'test/testdata/workitem.xml';
+    private $filename = __DIR__  . '/testdata/workitem.xml';
 
     public function testConstruct01()
     {

--- a/test/requirements.php
+++ b/test/requirements.php
@@ -1,6 +1,0 @@
-<?php
-/**
- * Include the requirements for testing.
- */
-
-require_once './vendor/autoload.php';


### PR DESCRIPTION
Composer from v2 is going to autoload only those classes that comply with PSR-4 standards. It has started throwing deprecation warning since recent release. This PR updates tests to comply with the same.

* Added PSR-4 mapping in composer.json
* Updated namespaces in tests
* Rename files to match with classes, so it conforms to PSR-4
* Updated tests to "use" classes instead of requiring those